### PR TITLE
Cleaning new System Explorer Contents

### DIFF
--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/plugin.xml
@@ -343,13 +343,10 @@
                viewerId="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer">
             <includes>
                <contentExtension isRoot="true"
-                    pattern="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.systemcontent">
+                    pattern="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.rootcontent">
                	</contentExtension>
                <contentExtension
                      pattern="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.automationsystemcontent">
-               </contentExtension>
-               <contentExtension
-                     pattern="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.eobjectcontent">
                </contentExtension>
                <contentExtension
                      pattern="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.sortOnly">
@@ -392,37 +389,14 @@
          point="org.eclipse.ui.navigator.navigatorContent">
         <navigatorContent
             activeByDefault="true"
-            contentProvider="org.eclipse.fordiac.ide.systemmanagement.ui.providers.SystemContentProvider"
-            id="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.systemcontent"
+            contentProvider="org.eclipse.fordiac.ide.systemmanagement.ui.providers.SystemExplorerRootContentProvider"
+            id="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.rootcontent"
             labelProvider="org.eclipse.fordiac.ide.systemmanagement.ui.systemexplorer.SystemLabelProvider"
             name="System Content"
             priority="high">
             <possibleChildren>
-	           <or>         
                  <instanceof value="org.eclipse.core.resources.IProject"/>
-                  <instanceof value="org.eclipse.core.resources.IResource"/>
-	              <instanceof value="org.eclipse.emf.ecore.EObject"/>
-	              <instanceof value="org.eclipse.emf.edit.provider.ItemProviderAdapter"/>
-	           </or>
 	        </possibleChildren> 
-            <triggerPoints>
-                <or>
-                    <instanceof value="org.eclipse.emf.ecore.EObject"/>
-                    <instanceof value="org.eclipse.core.resources.IFolder"/>
-                    <adapt type="org.eclipse.core.resources.IProject" >
-                        <test property="org.eclipse.core.resources.projectNature" value="org.eclipse.fordiac.ide.systemmanagement.FordiacNature"/>
-                    </adapt>
-                    <instanceof value="org.eclipse.core.resources.IWorkspaceRoot" />
-                    <and>
-                        <instanceof value="org.eclipse.core.resources.IFile" />
-                        <test
-                            forcePluginActivation="true"   
-                            property="org.eclipse.core.resources.extension"
-                            value="sys">
-                        </test>                   
-                    </and>
-                </or>
-            </triggerPoints>
        </navigatorContent>
         <navigatorContent
               activeByDefault="true"

--- a/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/SystemExplorerRootContentProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.systemmanagement.ui/src/org/eclipse/fordiac/ide/systemmanagement/ui/providers/SystemExplorerRootContentProvider.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2015, 2016 fortiss GmbH
- * 				 2020 Johannes Kepler University Linz
+ * Copyright (c) 2015, 2024 fortiss GmbH, Johannes Kepler University Linz
+ * 							Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,24 +16,22 @@
 package org.eclipse.fordiac.ide.systemmanagement.ui.providers;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 import org.eclipse.core.resources.IProject;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.resources.IWorkspaceRoot;
 import org.eclipse.core.runtime.CoreException;
-import org.eclipse.emf.edit.provider.ComposedAdapterFactory;
-import org.eclipse.emf.edit.ui.provider.AdapterFactoryContentProvider;
 import org.eclipse.fordiac.ide.systemmanagement.SystemManager;
 import org.eclipse.fordiac.ide.systemmanagement.changelistener.DistributedSystemListener;
 import org.eclipse.fordiac.ide.ui.FordiacLogHelper;
+import org.eclipse.jface.viewers.ITreeContentProvider;
+import org.eclipse.jface.viewers.Viewer;
 
-public class SystemContentProvider extends AdapterFactoryContentProvider implements DistributedSystemListener {
+public class SystemExplorerRootContentProvider implements ITreeContentProvider, DistributedSystemListener {
 
-	private static ComposedAdapterFactory systemAdapterFactory = new ComposedAdapterFactory(Collections.emptyList());
+	private Viewer viewer;
 
-	public SystemContentProvider() {
-		super(systemAdapterFactory);
+	public SystemExplorerRootContentProvider() {
 		SystemManager.INSTANCE.addWorkspaceListener(this);
 	}
 
@@ -45,9 +43,14 @@ public class SystemContentProvider extends AdapterFactoryContentProvider impleme
 	@Override
 	public Object[] getChildren(final Object parentElement) {
 		if (parentElement instanceof final IWorkspaceRoot root) {
-			return Arrays.stream(root.getProjects()).filter(SystemContentProvider::projectToShow).toArray();
+			return Arrays.stream(root.getProjects()).filter(SystemExplorerRootContentProvider::projectToShow).toArray();
 		}
 		return new Object[0];
+	}
+
+	@Override
+	public void inputChanged(final Viewer viewer, final Object oldInput, final Object newInput) {
+		this.viewer = viewer;
 	}
 
 	@Override
@@ -68,7 +71,7 @@ public class SystemContentProvider extends AdapterFactoryContentProvider impleme
 				return true;
 			}
 		}
-		return super.hasChildren(element);
+		return false;
 	}
 
 	@Override

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/FBTypeContentProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/FBTypeContentProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2024 TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2011, 2024 TU Wien ACIN, fortiss GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -16,8 +16,6 @@
 package org.eclipse.fordiac.ide.typemanagement.navigator;
 
 import org.eclipse.core.resources.IFile;
-import org.eclipse.core.resources.IResource;
-import org.eclipse.fordiac.ide.model.libraryElement.FBType;
 
 public class FBTypeContentProvider extends LibraryElementContentProvider {
 
@@ -27,11 +25,8 @@ public class FBTypeContentProvider extends LibraryElementContentProvider {
 
 	@Override
 	public Object getParent(final Object element) {
-		if (element instanceof IFile) {
-			return ((IResource) element).getParent();
-		}
-		if (element instanceof final FBType fbtype) {
-			return fbtype.getTypeEntry().getFile();
+		if (element instanceof final IFile file) {
+			return file.getParent();
 		}
 		return super.getParent(element);
 	}

--- a/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/LibraryElementContentProvider.java
+++ b/plugins/org.eclipse.fordiac.ide.typemanagement/src/org/eclipse/fordiac/ide/typemanagement/navigator/LibraryElementContentProvider.java
@@ -1,5 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2011 - 2024 TU Wien ACIN, fortiss GmbH
+ * Copyright (c) 2011, 2024 TU Wien ACIN, fortiss GmbH
+ * 							Primetals Technologies Austria GmbH
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License 2.0 which is available at
@@ -58,8 +59,17 @@ public class LibraryElementContentProvider extends AdapterFactoryContentProvider
 	}
 
 	@Override
-	public Object[] getChildren(Object parentElement) {
-		parentElement = getTypeParent(parentElement);
+	public Object[] getChildren(final Object parentElement) {
+		if (parentElement instanceof final IFile element) {
+			final TypeEntry entry = TypeLibraryManager.INSTANCE.getTypeEntryForFile(element);
+			if (null != entry) {
+				hookToTypeEntry(entry);
+				return super.getChildren(entry.getTypeEditable());
+			}
+			// we don't have a type entry for the full so we don't have children
+			return new Object[0];
+		}
+
 		return super.getChildren(parentElement);
 	}
 
@@ -70,28 +80,6 @@ public class LibraryElementContentProvider extends AdapterFactoryContentProvider
 			return libElement.getTypeEntry().getFile();
 		}
 		return parent;
-	}
-
-	/**
-	 * Get the correct type if it exists
-	 *
-	 * Note: use in {@link #getChildren(Object)} to obtain the correct object
-	 *
-	 * @param parentElement
-	 * @return the parentElement or its respective type
-	 */
-	protected Object getTypeParent(final Object parentElement) {
-		TypeEntry entry = null;
-		if (parentElement instanceof final IFile element) {
-			entry = TypeLibraryManager.INSTANCE.getTypeEntryForFile(element);
-		} else if (parentElement instanceof final LibraryElement element) {
-			entry = element.getTypeEntry();
-		}
-		if (null != entry) {
-			hookToTypeEntry(entry);
-			return entry.getTypeEditable();
-		}
-		return parentElement;
 	}
 
 	/**


### PR DESCRIPTION
With the separation of concerns into individual content providers more clean-ups are possible. Certain checks are not necessary anymore as well as children and triggerpoints are simpler.